### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:7-apache
+
+COPY .htaccess words.gz wpoison.php /var/www/html/
+
+RUN \
+  a2enmod rewrite && \
+  mkdir --verbose --preserve members && \
+  gunzip words.gz && \
+  mv --verbose words members/ && \
+  mv --verbose wpoison.php members/email.php

--- a/wpoison.php
+++ b/wpoison.php
@@ -87,6 +87,7 @@ print ("</BIG>\n</BODY>\n</HTML>\n");
 // end of the HTML part
 // Functions
 function randomwords($min, $max) {
+  $string = "";
   $lines = file("words"); // dictionary file
   for ($a = 0; $a <= mt_rand($min, $max); $a++) {
     $string .= str_replace("\n", '', $lines[mt_rand(1, 235880)]) . " "; // concatenate the words while removing the carriage return from them


### PR DESCRIPTION
Provides a Dockerfile to allow running wpoison without any dependencies other than Docker (no PHP, no Apache). It can be also used to develop without any runtime dependencies, too.
## To build:
### from local checkout:
``` bash
docker build -t wpoison .
```
### directly from repo (no checkout needed):
``` bash
docker build -t wpoison github.com/pataquets/wpoison-anti-junk-emailers
```
Notice: use the 2nd method above to quickly test this PR.

## To run:
After building, just run the service:
``` bash
docker run --rm -it -p 8080:80 wpoison
```
You can now browse http://localhost:8080/members/email/